### PR TITLE
[BUG] AppendAllLines concatenates content into one line

### DIFF
--- a/AlphaFS.UnitTest/File Class/FileTest.cs
+++ b/AlphaFS.UnitTest/File Class/FileTest.cs
@@ -2359,6 +2359,23 @@ namespace AlphaFS.UnitTest
          DumpAppendAllLines(false);
       }
 
+      [TestMethod]
+      public void AppendAllLinesThenReadAllLinesShouldReturnSameCollection()
+      {
+         var file = Path.GetTempFileName();
+         var sample = new []{ "line one", "line two" };
+
+         try
+         {
+            File.AppendAllLines(file, sample);
+            CollectionAssert.AreEquivalent(sample, File.ReadAllLines(file).ToArray());
+         }
+         finally
+         {
+            File.Delete(file);
+         }
+      }
+
       #endregion // AppendAllLines
 
       #region AppendAllText

--- a/AlphaFS/Filesystem/File Class/File.WriteText.cs
+++ b/AlphaFS/Filesystem/File Class/File.WriteText.cs
@@ -57,7 +57,7 @@ namespace Alphaleonis.Win32.Filesystem
       [SecurityCritical]
       public static void AppendAllLines(string path, IEnumerable<string> contents)
       {
-         WriteAppendAllLinesCore(null, path, contents, NativeMethods.DefaultFileEncoding, true, false, PathFormat.RelativePath);
+         WriteAppendAllLinesCore(null, path, contents, NativeMethods.DefaultFileEncoding, true, true, PathFormat.RelativePath);
       }
 
       /// <summary>Appends lines to a file, and then closes the file. If the specified file does not exist, this method creates a file, writes the


### PR DESCRIPTION
Found bug in AppendAllLines method: it not uses WriteLine method of StreamWriter (addNewLine parameter of WriteAppendAllLinesCore)

Fixed.
