### PR TITLE
Fix Long Path Prefix of GLOBALROOT missing.

### DIFF
--- a/AlphaFS/Filesystem/FindFileSystemEntryInfo.cs
+++ b/AlphaFS/Filesystem/FindFileSystemEntryInfo.cs
@@ -159,7 +159,7 @@ namespace Alphaleonis.Win32.Filesystem
          // true = Return only directories.
          // false = Return only files.
 
-         var fsei = new FileSystemEntryInfo(win32FindData) { FullPath = Path.GetRegularPathCore(fullPathLp, GetFullPathOptions.None) };
+         var fsei = new FileSystemEntryInfo(win32FindData) { FullPath = fullPathLp };
 
          return AsFileSystemInfo
             // Return object instance of type FileSystemInfo.


### PR DESCRIPTION
I found bug in DirectoryInfo.GetFileSystemInfos method.
When this method is called, it lose Long Path Prefix of GLOBALROOT path.

Please review.
