### PR TITLE
Fix #181 (OpenWrite should create file if it doesn't exist)

### DIFF
--- a/AlphaFS/Filesystem/FileInfo Class/FileInfo.OpenWrite.cs
+++ b/AlphaFS/Filesystem/FileInfo Class/FileInfo.OpenWrite.cs
@@ -33,7 +33,7 @@ namespace Alphaleonis.Win32.Filesystem
       [SecurityCritical]
       public FileStream OpenWrite()
       {
-         return File.OpenCore(Transaction, LongFullName, FileMode.Open, FileAccess.Write, FileShare.None, ExtendedFileAttributes.Normal, null, null, PathFormat.LongFullPath);
+         return File.OpenCore(Transaction, LongFullName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None, ExtendedFileAttributes.Normal, null, null, PathFormat.LongFullPath);
       }
 
       #endregion // .NET


### PR DESCRIPTION
Just changed FileMode.Create to FileMode.OpenOrCreate (same as in the
System.IO implementation)
