### PR TITLE
Fix: Prevent normalization of GlobalRootPrefix paths

### DIFF
--- a/AlphaFS/Filesystem/Path Class/Path.ShortLongConversions.cs
+++ b/AlphaFS/Filesystem/Path Class/Path.ShortLongConversions.cs
@@ -229,7 +229,8 @@ namespace Alphaleonis.Win32.Filesystem
          if (options != GetFullPathOptions.None)
             path = ApplyFullPathOptions(path, options);
 
-         return !path.StartsWith(LongPathPrefix, StringComparison.OrdinalIgnoreCase)
+         return path.StartsWith(GlobalRootPrefix, StringComparison.OrdinalIgnoreCase)
+            || !path.StartsWith(LongPathPrefix, StringComparison.OrdinalIgnoreCase)
             ? path
             : (path.StartsWith(LongPathUncPrefix, StringComparison.OrdinalIgnoreCase)
                ? UncPrefix + path.Substring(LongPathUncPrefix.Length)


### PR DESCRIPTION
Paths starting with the GLOBALROOT prefix should not be normalized by removing the long path prefix, otherwise they are indistinguishable from normal relative paths. This patch prevents that normalization.
