### PR TITLE
Enable null for  destinationBackupFileName in File.Replace and FileInfo.Replace

### DIFF
--- a/AlphaFS/Filesystem/File Class/File.Replace.cs
+++ b/AlphaFS/Filesystem/File Class/File.Replace.cs
@@ -157,7 +157,10 @@ namespace Alphaleonis.Win32.Filesystem
          string destinationFileNameLp = Path.GetExtendedLengthPathCore(null, destinationFileName, pathFormat, options);
          
          // Pass null to the destinationBackupFileName parameter if you do not want to create a backup of the file being replaced.
-         string destinationBackupFileNameLp = Path.GetExtendedLengthPathCore(null, destinationBackupFileName, pathFormat, options);
+         string destinationBackupFileNameLp =
+                destinationBackupFileName != null?
+                    Path.GetExtendedLengthPathCore(null, destinationBackupFileName, pathFormat, options) :
+                    null;
 
          const int replacefileWriteThrough = 1;
          const int replacefileIgnoreMergeErrors = 2;

--- a/AlphaFS/Filesystem/FileInfo Class/FileInfo.Replace.cs
+++ b/AlphaFS/Filesystem/FileInfo Class/FileInfo.Replace.cs
@@ -81,7 +81,10 @@ namespace Alphaleonis.Win32.Filesystem
          var options = GetFullPathOptions.RemoveTrailingDirectorySeparator | GetFullPathOptions.FullCheck;
 
          string destinationFileNameLp = Path.GetExtendedLengthPathCore(Transaction, destinationFileName, pathFormat, options);
-         string destinationBackupFileNameLp = Path.GetExtendedLengthPathCore(Transaction, destinationBackupFileName, pathFormat, options);
+         string destinationBackupFileNameLp =
+                destinationBackupFileName != null?
+                    Path.GetExtendedLengthPathCore(Transaction, destinationBackupFileName, pathFormat, options):
+                    null;
 
          File.ReplaceCore(LongFullName, destinationFileNameLp, destinationBackupFileNameLp, false, PathFormat.LongFullPath);
 
@@ -106,7 +109,10 @@ namespace Alphaleonis.Win32.Filesystem
          var options = GetFullPathOptions.RemoveTrailingDirectorySeparator | GetFullPathOptions.FullCheck;
 
          string destinationFileNameLp = Path.GetExtendedLengthPathCore(Transaction, destinationFileName, pathFormat, options);
-         string destinationBackupFileNameLp = Path.GetExtendedLengthPathCore(Transaction, destinationBackupFileName, pathFormat, options);
+            string destinationBackupFileNameLp =
+                   destinationBackupFileName != null ?
+                       Path.GetExtendedLengthPathCore(Transaction, destinationBackupFileName, pathFormat, options) :
+                       null; 
 
          File.ReplaceCore(LongFullName, destinationFileNameLp, destinationBackupFileNameLp, ignoreMetadataErrors, PathFormat.LongFullPath);
 


### PR DESCRIPTION
Seems to be related to #217
