### PR TITLE
Enable Path.IsRooted for the empty string

### DIFF
--- a/AlphaFS/Filesystem/Path Class/Path.ValidationAndChecks.cs
+++ b/AlphaFS/Filesystem/Path Class/Path.ValidationAndChecks.cs
@@ -83,7 +83,7 @@ namespace Alphaleonis.Win32.Filesystem
       [SecurityCritical]
       public static bool IsPathRooted(string path, bool checkInvalidPathChars)
       {
-         if (path != null)
+         if (!string.IsNullOrEmpty(path))
          {
             if (checkInvalidPathChars)
                CheckInvalidPathChars(path, false);


### PR DESCRIPTION
.Net 4.5 just returns false
