### PR TITLE
Fixes #279: The unit tests for CRC32/64 are failing.

### DIFF
--- a/AlphaFS.UnitTest/Crc Class/AlphaFS_Class_Crc32.cs
+++ b/AlphaFS.UnitTest/Crc Class/AlphaFS_Class_Crc32.cs
@@ -19,12 +19,13 @@
  *  THE SOFTWARE. 
  */
 
-using Alphaleonis.Win32.Security;
+using System;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
 
 namespace AlphaFS.UnitTest
 {
+   [TestClass]
    public class Crc32Test
    {
       // Pattern: <class>_<function>_<scenario>_<expected result>
@@ -32,10 +33,15 @@ namespace AlphaFS.UnitTest
       [TestMethod]
       public void AlphaFS_Class_Crc32_StaticDefaultSeedAndPolynomialWithShortAsciiString()
       {
-         using (var crc32 = new Crc32())
+         using (var crc32 = new Alphaleonis.Win32.Security.Crc32())
          {
-            var actual = crc32.ComputeHash(System.Text.Encoding.ASCII.GetBytes(UnitTestConstants.StreamArrayContent[0]));
-            Assert.AreEqual((uint)2048436515, actual);
+            var text = UnitTestConstants.StreamArrayContent[0];
+            var hash = crc32.ComputeHash(System.Text.Encoding.ASCII.GetBytes(text)).Aggregate(string.Empty, (current, b) => current + b.ToString("x2").ToLower());
+               
+            Console.WriteLine("Input text: {0}", text);
+            Console.WriteLine("\n\tCRC32: {0}", hash);
+
+            Assert.AreEqual("7a18a923", hash);
          }
       }
 
@@ -43,10 +49,15 @@ namespace AlphaFS.UnitTest
       [TestMethod]
       public void AlphaFS_Class_Crc32_StaticDefaultSeedAndPolynomialWithShortAsciiString2()
       {
-         using (var crc32 = new Crc32())
+         using (var crc32 = new Alphaleonis.Win32.Security.Crc32())
          {
-            var actual = crc32.ComputeHash(System.Text.Encoding.ASCII.GetBytes(UnitTestConstants.StreamArrayContent[1]));
-            Assert.AreEqual(2244818965, actual);
+            var text = UnitTestConstants.StreamArrayContent[1];
+            var hash = crc32.ComputeHash(System.Text.Encoding.ASCII.GetBytes(text)).Aggregate(string.Empty, (current, b) => current + b.ToString("x2").ToLower());
+
+            Console.WriteLine("Input text: {0}", text);
+            Console.WriteLine("\n\tCRC32: {0}", hash);
+
+            Assert.AreEqual("85cd3815", hash);
          }
       }
    }

--- a/AlphaFS.UnitTest/Crc Class/AlphaFS_Class_Crc64.cs
+++ b/AlphaFS.UnitTest/Crc Class/AlphaFS_Class_Crc64.cs
@@ -19,11 +19,13 @@
  *  THE SOFTWARE. 
  */
 
-using Alphaleonis.Win32.Security;
+using System;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace AlphaFS.UnitTest
 {
+   [TestClass]
    public class Crc64Test
    {
       // Pattern: <class>_<function>_<scenario>_<expected result>
@@ -31,22 +33,31 @@ namespace AlphaFS.UnitTest
       [TestMethod]
       public void AlphaFS_Class_Crc64Iso_StaticDefaultSeedAndPolynomialWithShortAsciiString()
       {
-         using (var crc64 = new Crc64())
+         using (var crc64 = new Alphaleonis.Win32.Security.Crc64())
          {
-            var actual = crc64.ComputeHash(System.Text.Encoding.ASCII.GetBytes(UnitTestConstants.StreamArrayContent[0]));
+            var text = UnitTestConstants.StreamArrayContent[0];
+            var hash = crc64.ComputeHash(System.Text.Encoding.ASCII.GetBytes(text)).Aggregate(string.Empty, (current, b) => current + b.ToString("x2").ToLower());
 
-            Assert.AreEqual((ulong)8233304910036677951, actual);
+            Console.WriteLine("Input text: {0}", text);
+            Console.WriteLine("\n\tCRC64: {0}", hash);
+
+            Assert.AreEqual("724293319a37353f", hash);
          }
       }
+
 
       [TestMethod]
       public void AlphaFS_Class_Crc64Iso_StaticDefaultSeedAndPolynomialWithShortAsciiString2()
       {
-         using (var crc64 = new Crc64())
+         using (var crc64 = new Alphaleonis.Win32.Security.Crc64())
          {
-            var actual = crc64.ComputeHash(System.Text.Encoding.ASCII.GetBytes(UnitTestConstants.StreamArrayContent[1]));
+            var text = UnitTestConstants.StreamArrayContent[1];
+            var hash = crc64.ComputeHash(System.Text.Encoding.ASCII.GetBytes(text)).Aggregate(string.Empty, (current, b) => current + b.ToString("x2").ToLower());
 
-            Assert.AreEqual((ulong)4995575162106563943, actual);
+            Console.WriteLine("Input text: {0}", text);
+            Console.WriteLine("\n\tCRC64: {0}", hash);
+
+            Assert.AreEqual("4553d9246a204d67", hash);
          }
       }
    }

--- a/AlphaFS.UnitTest/File Class/File_Copy.cs
+++ b/AlphaFS.UnitTest/File Class/File_Copy.cs
@@ -305,7 +305,8 @@ namespace AlphaFS.UnitTest
             if (isNetwork)
                fileCopy = Alphaleonis.Win32.Filesystem.Path.LocalToUnc(fileCopy);
 
-            Console.WriteLine("\nInput File Path: [{0}]", fileSource);
+            Console.WriteLine("\nSrc File Path: [{0}]", fileSource);
+            Console.WriteLine("Dst File Path: [{0}]", fileCopy);
 
 
             var gotException = false;

--- a/AlphaFS.UnitTest/File Class/File_Move.cs
+++ b/AlphaFS.UnitTest/File Class/File_Move.cs
@@ -352,7 +352,8 @@ namespace AlphaFS.UnitTest
             if (isNetwork)
                fileCopy = Alphaleonis.Win32.Filesystem.Path.LocalToUnc(fileCopy);
 
-            Console.WriteLine("\nInput File Path: [{0}]", fileSource);
+            Console.WriteLine("\nSrc File Path: [{0}]", fileSource);
+            Console.WriteLine("Dst File Path: [{0}]", fileCopy);
 
 
             var gotException = false;


### PR DESCRIPTION
Small textual tweak to unit tests File.Copy/Move
