### PR TITLE
Fix returned values from EnumerateDomainDfsRootCore() 

### DIFF
--- a/AlphaFS/Network/Host Class/DistributedFileSystem.cs
+++ b/AlphaFS/Network/Host Class/DistributedFileSystem.cs
@@ -226,7 +226,8 @@ namespace Alphaleonis.Win32.Network
 
          return EnumerateNetworkObjectCore(new FunctionData(), (NativeMethods.DFS_INFO_200 structure, SafeGlobalMemoryBufferHandle buffer) =>
 
-            new DfsInfo { EntryPath = string.Format(CultureInfo.CurrentCulture, "{0}{1}{2}{3}", Path.UncPrefix, NativeMethods.ComputerDomain, Path.DirectorySeparatorChar, structure.FtDfsName) },
+            new DfsInfo { EntryPath = string.Format(CultureInfo.CurrentCulture, "{0}{1}{2}{3}", Path.UncPrefix, 
+                    Utils.IsNullOrWhiteSpace(domain) ? NativeMethods.ComputerDomain : domain, Path.DirectorySeparatorChar, structure.FtDfsName) },
 
             (FunctionData functionData, out SafeGlobalMemoryBufferHandle buffer, int prefMaxLen, out uint entriesRead, out uint totalEntries, out uint resumeHandle) =>
             {


### PR DESCRIPTION
This is for issue #297  When a "domain" is given as a parameter, the returned UNC paths include an incorrect domain name.

Please let me know if I have something wrong with this pull request, as this is my first venture into using this on GitHub.

Thanks!