### PR TITLE
Added Feature: Directory.GetFileSystemEntryInfo

### DIFF
--- a/AlphaFS/AlphaFS.csproj
+++ b/AlphaFS/AlphaFS.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Filesystem\AlternateDataStreamInfo.cs" />
     <Compile Include="Filesystem\BackupStreamInfo.cs" />
     <Compile Include="Filesystem\Directory Class\Directory.GetDirectoryId.cs" />
+    <Compile Include="Filesystem\Directory Class\Directory.GetFileSystemEntryInfo.cs" />
     <Compile Include="Filesystem\FileId.cs" />
     <Compile Include="Filesystem\CopyMoveProgressRoutine.cs" />
     <Compile Include="Filesystem\Directory Class\Directory.CopyMove.cs" />

--- a/AlphaFS/AlphaFS.csproj
+++ b/AlphaFS/AlphaFS.csproj
@@ -198,6 +198,8 @@
     </Compile>
     <Compile Include="Filesystem\AlternateDataStreamInfo.cs" />
     <Compile Include="Filesystem\BackupStreamInfo.cs" />
+    <Compile Include="Filesystem\Directory Class\Directory.GetDirectoryId.cs" />
+    <Compile Include="Filesystem\FileId.cs" />
     <Compile Include="Filesystem\CopyMoveProgressRoutine.cs" />
     <Compile Include="Filesystem\Directory Class\Directory.CopyMove.cs" />
     <Compile Include="Filesystem\Directory Class\Directory.CountFileSystemObjects.cs" />
@@ -233,6 +235,8 @@
     <Compile Include="Filesystem\Directory Class\Directory.EnumerateFileIdBothDirectoryInfo.cs" />
     <Compile Include="Filesystem\Directory Class\Directory.GetProperties.cs" />
     <Compile Include="Filesystem\Directory Class\Directory.EnumerateAlternateDataStreams.cs" />
+    <Compile Include="Filesystem\Directory Class\Directory.GetLinkTargetInfo.cs" />
+    <Compile Include="Filesystem\DirectoryEnumerationFilters.cs" />
     <Compile Include="Filesystem\DirectoryInfo Class\DirectoryInfo.RefreshEntryInfo.cs" />
     <Compile Include="Filesystem\DirectoryInfo Class\DirectoryInfo.Encryption.cs" />
     <Compile Include="Filesystem\DirectoryInfo Class\DirectoryInfo.DeleteEmptySubdirectories.cs" />
@@ -262,6 +266,7 @@
     <Compile Include="Filesystem\Exceptions\DirectoryReadOnlyException.cs" />
     <Compile Include="Filesystem\Exceptions\DirectoryNotEmptyException.cs" />
     <Compile Include="Filesystem\Exceptions\FileReadOnlyException.cs" />
+    <Compile Include="Filesystem\File Class\File.GetFileId.cs" />
     <Compile Include="Filesystem\File Class\File.GetHash.cs" />
     <Compile Include="Filesystem\File Class\File.EncryptedFileRaw.cs" />
     <Compile Include="Filesystem\File Class\File.EnumerateAlternateDataStreams.cs" />
@@ -374,6 +379,7 @@
     <Compile Include="Filesystem\Native Methods\NativeMethods.BackupStreams.cs" />
     <Compile Include="Filesystem\Native Methods\NativeMethods.Utilities.cs" />
     <Compile Include="Filesystem\Native Methods\NativeMethods.PathManagement.cs" />
+    <Compile Include="Filesystem\Native Structures\FILE_ID_INFO.cs" />
     <Compile Include="Filesystem\Native Structures\WIN32_FIND_STREAM_DATA.cs" />
     <Compile Include="Filesystem\Path Class\Path.cs" />
     <Compile Include="Filesystem\Path Class\Path.ValidationAndChecks.cs" />
@@ -528,7 +534,7 @@
   -->
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties Reset="1" AssemblyVersion="0" AssemblyFileVersion="0" StartDate="20080813" />
+      <UserProperties StartDate="20080813" AssemblyFileVersion="0" AssemblyVersion="0" Reset="1" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/AlphaFS/Filesystem/Directory Class/Directory.EnumerateDirectories.cs
+++ b/AlphaFS/Filesystem/Directory Class/Directory.EnumerateDirectories.cs
@@ -103,6 +103,70 @@ namespace Alphaleonis.Win32.Filesystem
       /// <exception cref="NotSupportedException"/>
       /// <exception cref="UnauthorizedAccessException"/>
       /// <param name="path">The directory to search.</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SecurityCritical]
+      public static IEnumerable<string> EnumerateDirectories(string path, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<string>(null, path, Path.WildcardStarMatchAll, DirectoryEnumerationOptions.Folders, PathFormat.RelativePath, filters);
+      }
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of directory names that match a <paramref name="searchPattern"/> in a specified <paramref name="path"/>.</summary>
+      /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/> and that match the specified <paramref name="searchPattern"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="searchPattern">
+      ///   The search string to match against the names of directories in <paramref name="path"/>.
+      ///   This parameter can contain a combination of valid literal path and wildcard
+      ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
+      /// </param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SecurityCritical]
+      public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<string>(null, path, searchPattern, DirectoryEnumerationOptions.Folders, PathFormat.RelativePath, filters);
+      }
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of directory names that match a <paramref name="searchPattern"/> in a specified <paramref name="path"/>, and optionally searches subdirectories.</summary>
+      /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/> and that match the specified <paramref name="searchPattern"/> and <paramref name="searchOption"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="searchPattern">
+      ///   The search string to match against the names of directories in <paramref name="path"/>.
+      ///   This parameter can contain a combination of valid literal path and wildcard
+      ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
+      /// </param>
+      /// <param name="searchOption">
+      ///   One of the <see cref="SearchOption"/> enumeration values that specifies whether the <paramref name="searchOption"/>
+      ///   should include only the current directory or should include all subdirectories.
+      /// </param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SecurityCritical]
+      public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption, DirectoryEnumerationFilters filters)
+      {
+         var options = DirectoryEnumerationOptions.Folders | ((searchOption == SearchOption.AllDirectories) ? DirectoryEnumerationOptions.Recursive : 0);
+
+         return EnumerateFileSystemEntryInfosCore<string>(null, path, searchPattern, options, PathFormat.RelativePath, filters);
+      }
+      
+      /// <summary>[AlphaFS] Returns an enumerable collection of directory names in a specified <paramref name="path"/>.</summary>
+      /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <param name="path">The directory to search.</param>
       /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
       [SecurityCritical]
       public static IEnumerable<string> EnumerateDirectories(string path, PathFormat pathFormat)
@@ -110,6 +174,24 @@ namespace Alphaleonis.Win32.Filesystem
          return EnumerateFileSystemEntryInfosCore<string>(null, path, Path.WildcardStarMatchAll, DirectoryEnumerationOptions.Folders, pathFormat);
       }
 
+      /// <summary>[AlphaFS] Returns an enumerable collection of directory names in a specified <paramref name="path"/>.</summary>
+      /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SecurityCritical]
+      public static IEnumerable<string> EnumerateDirectories(string path, PathFormat pathFormat, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<string>(null, path, Path.WildcardStarMatchAll, DirectoryEnumerationOptions.Folders, pathFormat, filters);
+      }
+
+      
 
 
       /// <summary>[AlphaFS] Returns an enumerable collection of directory names that match a <paramref name="searchPattern"/> in a specified <paramref name="path"/>.</summary>
@@ -132,6 +214,30 @@ namespace Alphaleonis.Win32.Filesystem
       {
          return EnumerateFileSystemEntryInfosCore<string>(null, path, searchPattern, DirectoryEnumerationOptions.Folders, pathFormat);
       }
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of directory names that match a <paramref name="searchPattern"/> in a specified <paramref name="path"/>.</summary>
+      /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/> and that match the specified <paramref name="searchPattern"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="searchPattern">
+      ///   The search string to match against the names of directories in <paramref name="path"/>.
+      ///   This parameter can contain a combination of valid literal path and wildcard
+      ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
+      /// </param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SecurityCritical]
+      public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, PathFormat pathFormat, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<string>(null, path, searchPattern, DirectoryEnumerationOptions.Folders, pathFormat, filters);
+      }
+
+      
 
       /// <summary>[AlphaFS] Returns an enumerable collection of directory names that match a <paramref name="searchPattern"/> in a specified <paramref name="path"/>, and optionally searches subdirectories.</summary>
       /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/> and that match the specified <paramref name="searchPattern"/> and <paramref name="searchOption"/>.</returns>
@@ -160,6 +266,35 @@ namespace Alphaleonis.Win32.Filesystem
          return EnumerateFileSystemEntryInfosCore<string>(null, path, searchPattern, options, pathFormat);
       }
 
+      /// <summary>[AlphaFS] Returns an enumerable collection of directory names that match a <paramref name="searchPattern"/> in a specified <paramref name="path"/>, and optionally searches subdirectories.</summary>
+      /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/> and that match the specified <paramref name="searchPattern"/> and <paramref name="searchOption"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="searchPattern">
+      ///   The search string to match against the names of directories in <paramref name="path"/>.
+      ///   This parameter can contain a combination of valid literal path and wildcard
+      ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
+      /// </param>
+      /// <param name="searchOption">
+      ///   One of the <see cref="SearchOption"/> enumeration values that specifies whether the <paramref name="searchOption"/>
+      ///   should include only the current directory or should include all subdirectories.
+      /// </param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SecurityCritical]
+      public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption, PathFormat pathFormat, DirectoryEnumerationFilters filters)
+      {
+         var options = DirectoryEnumerationOptions.Folders | ((searchOption == SearchOption.AllDirectories) ? DirectoryEnumerationOptions.Recursive : 0);
+
+         return EnumerateFileSystemEntryInfosCore<string>(null, path, searchPattern, options, pathFormat, filters);
+      }
+
+      
 
 
       /// <summary>[AlphaFS] Returns an enumerable collection of directory names in a specified <paramref name="path"/>.</summary>
@@ -192,6 +327,29 @@ namespace Alphaleonis.Win32.Filesystem
       /// <exception cref="UnauthorizedAccessException"/>
       /// <param name="path">The directory to search.</param>
       /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SecurityCritical]
+      public static IEnumerable<string> EnumerateDirectories(string path, DirectoryEnumerationOptions options, DirectoryEnumerationFilters filters)
+      {
+         // Adhere to the method name.
+         options &= ~DirectoryEnumerationOptions.Files;  // Remove enumeration of files.
+         options |= DirectoryEnumerationOptions.Folders; // Add enumeration of directories.
+
+         return EnumerateFileSystemEntryInfosCore<string>(null, path, Path.WildcardStarMatchAll, options, PathFormat.RelativePath, filters);
+      }
+
+      
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of directory names in a specified <paramref name="path"/>.</summary>
+      /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
       /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
       [SecurityCritical]
       public static IEnumerable<string> EnumerateDirectories(string path, DirectoryEnumerationOptions options, PathFormat pathFormat)
@@ -203,7 +361,29 @@ namespace Alphaleonis.Win32.Filesystem
          return EnumerateFileSystemEntryInfosCore<string>(null, path, Path.WildcardStarMatchAll, options, pathFormat);
       }
 
+      /// <summary>[AlphaFS] Returns an enumerable collection of directory names in a specified <paramref name="path"/>.</summary>
+      /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SecurityCritical]
+      public static IEnumerable<string> EnumerateDirectories(string path, DirectoryEnumerationOptions options, PathFormat pathFormat, DirectoryEnumerationFilters filters)
+      {
+         // Adhere to the method name.
+         options &= ~DirectoryEnumerationOptions.Files;
+         options |= DirectoryEnumerationOptions.Folders;
 
+         return EnumerateFileSystemEntryInfosCore<string>(null, path, Path.WildcardStarMatchAll, options, pathFormat, filters);
+      }
+
+      
 
       /// <summary>[AlphaFS] Returns an enumerable collection of directory names in a specified <paramref name="path"/>.</summary>
       /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/>.</returns>
@@ -245,6 +425,34 @@ namespace Alphaleonis.Win32.Filesystem
       ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
       /// </param>
       /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SecurityCritical]
+      public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, DirectoryEnumerationOptions options, DirectoryEnumerationFilters filters)
+      {
+         // Adhere to the method name.
+         options &= ~DirectoryEnumerationOptions.Files;
+         options |= DirectoryEnumerationOptions.Folders;
+
+         return EnumerateFileSystemEntryInfosCore<string>(null, path, searchPattern, options, PathFormat.RelativePath, filters);
+      }
+
+      
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of directory names in a specified <paramref name="path"/>.</summary>
+      /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="searchPattern">
+      ///   The search string to match against the names of directories in <paramref name="path"/>.
+      ///   This parameter can contain a combination of valid literal path and wildcard
+      ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
+      /// </param>
+      /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
       /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
       [SecurityCritical]
       public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, DirectoryEnumerationOptions options, PathFormat pathFormat)
@@ -255,8 +463,35 @@ namespace Alphaleonis.Win32.Filesystem
 
          return EnumerateFileSystemEntryInfosCore<string>(null, path, searchPattern, options, pathFormat);
       }
-      
 
+      /// <summary>[AlphaFS] Returns an enumerable collection of directory names in a specified <paramref name="path"/>.</summary>
+      /// <returns>An enumerable collection of the full names (including paths) for the directories in the directory specified by <paramref name="path"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="searchPattern">
+      ///   The search string to match against the names of directories in <paramref name="path"/>.
+      ///   This parameter can contain a combination of valid literal path and wildcard
+      ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
+      /// </param>
+      /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SecurityCritical]
+      public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, DirectoryEnumerationOptions options, PathFormat pathFormat, DirectoryEnumerationFilters filters)
+      {
+         // Adhere to the method name.
+         options &= ~DirectoryEnumerationOptions.Files;
+         options |= DirectoryEnumerationOptions.Folders;
+
+         return EnumerateFileSystemEntryInfosCore<string>(null, path, searchPattern, options, pathFormat, filters);
+      }
+
+     
 
       #region Transactional
 

--- a/AlphaFS/Filesystem/Directory Class/Directory.EnumerateFileSystemEntryInfos.cs
+++ b/AlphaFS/Filesystem/Directory Class/Directory.EnumerateFileSystemEntryInfos.cs
@@ -86,12 +86,79 @@ namespace Alphaleonis.Win32.Filesystem
       /// </list>
       /// </typeparam>
       /// <param name="path">The directory to search.</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
+      [SecurityCritical]
+      public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<T>(null, path, Path.WildcardStarMatchAll, DirectoryEnumerationOptions.FilesAndFolders, PathFormat.RelativePath, filters);
+      }
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of file system entries in a specified path.</summary>
+      /// <returns>The matching file system entries. The type of the items is determined by the type <typeparamref name="T"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <typeparam name="T">The type to return. This may be one of the following types:
+      ///    <list type="definition">
+      ///    <item>
+      ///       <term><see cref="FileSystemEntryInfo"/></term>
+      ///       <description>This method will return instances of <see cref="FileSystemEntryInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="FileSystemInfo"/></term>
+      ///       <description>This method will return instances of <see cref="DirectoryInfo"/> and <see cref="FileInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="string"/></term>
+      ///       <description>This method will return the full path of each item.</description>
+      ///    </item>
+      /// </list>
+      /// </typeparam>
+      /// <param name="path">The directory to search.</param>
       /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
       [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
       [SecurityCritical]
       public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, PathFormat pathFormat)
       {
          return EnumerateFileSystemEntryInfosCore<T>(null, path, Path.WildcardStarMatchAll, DirectoryEnumerationOptions.FilesAndFolders, pathFormat);
+      }
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of file system entries in a specified path.</summary>
+      /// <returns>The matching file system entries. The type of the items is determined by the type <typeparamref name="T"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <typeparam name="T">The type to return. This may be one of the following types:
+      ///    <list type="definition">
+      ///    <item>
+      ///       <term><see cref="FileSystemEntryInfo"/></term>
+      ///       <description>This method will return instances of <see cref="FileSystemEntryInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="FileSystemInfo"/></term>
+      ///       <description>This method will return instances of <see cref="DirectoryInfo"/> and <see cref="FileInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="string"/></term>
+      ///       <description>This method will return the full path of each item.</description>
+      ///    </item>
+      /// </list>
+      /// </typeparam>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
+      [SecurityCritical]
+      public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, PathFormat pathFormat, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<T>(null, path, Path.WildcardStarMatchAll, DirectoryEnumerationOptions.FilesAndFolders, pathFormat, filters);
       }
 
 
@@ -155,6 +222,40 @@ namespace Alphaleonis.Win32.Filesystem
       /// </typeparam>
       /// <param name="path">The directory to search.</param>
       /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
+      [SecurityCritical]
+      public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, DirectoryEnumerationOptions options, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<T>(null, path, Path.WildcardStarMatchAll, options, PathFormat.RelativePath, filters);
+      }
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of file system entries in a specified path.</summary>
+      /// <returns>The matching file system entries. The type of the items is determined by the type <typeparamref name="T"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <typeparam name="T">The type to return. This may be one of the following types:
+      ///    <list type="definition">
+      ///    <item>
+      ///       <term><see cref="FileSystemEntryInfo"/></term>
+      ///       <description>This method will return instances of <see cref="FileSystemEntryInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="FileSystemInfo"/></term>
+      ///       <description>This method will return instances of <see cref="DirectoryInfo"/> and <see cref="FileInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="string"/></term>
+      ///       <description>This method will return the full path of each item.</description>
+      ///    </item>
+      /// </list>
+      /// </typeparam>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
       /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
       [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
       [SecurityCritical]
@@ -163,6 +264,40 @@ namespace Alphaleonis.Win32.Filesystem
          return EnumerateFileSystemEntryInfosCore<T>(null, path, Path.WildcardStarMatchAll, options, pathFormat);
       }
 
+      /// <summary>[AlphaFS] Returns an enumerable collection of file system entries in a specified path.</summary>
+      /// <returns>The matching file system entries. The type of the items is determined by the type <typeparamref name="T"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <typeparam name="T">The type to return. This may be one of the following types:
+      ///    <list type="definition">
+      ///    <item>
+      ///       <term><see cref="FileSystemEntryInfo"/></term>
+      ///       <description>This method will return instances of <see cref="FileSystemEntryInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="FileSystemInfo"/></term>
+      ///       <description>This method will return instances of <see cref="DirectoryInfo"/> and <see cref="FileInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="string"/></term>
+      ///       <description>This method will return the full path of each item.</description>
+      ///    </item>
+      /// </list>
+      /// </typeparam>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
+      [SecurityCritical]
+      public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, DirectoryEnumerationOptions options, PathFormat pathFormat, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<T>(null, path, Path.WildcardStarMatchAll, options, pathFormat, filters);
+      }
 
 
       /// <summary>[AlphaFS] Returns an enumerable collection of file system entries that match a <paramref name="searchPattern" /> in a specified path.</summary>
@@ -200,6 +335,44 @@ namespace Alphaleonis.Win32.Filesystem
       public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, string searchPattern)
       {
          return EnumerateFileSystemEntryInfosCore<T>(null, path, searchPattern, DirectoryEnumerationOptions.FilesAndFolders, PathFormat.RelativePath);
+      }
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of file system entries that match a <paramref name="searchPattern" /> in a specified path.</summary>
+      /// <returns>The matching file system entries. The type of the items is determined by the type <typeparamref name="T"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <typeparam name="T">The type to return. This may be one of the following types:
+      ///    <list type="definition">
+      ///    <item>
+      ///       <term><see cref="FileSystemEntryInfo"/></term>
+      ///       <description>This method will return instances of <see cref="FileSystemEntryInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="FileSystemInfo"/></term>
+      ///       <description>This method will return instances of <see cref="DirectoryInfo"/> and <see cref="FileInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="string"/></term>
+      ///       <description>This method will return the full path of each item.</description>
+      ///    </item>
+      /// </list>
+      /// </typeparam>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="searchPattern">
+      ///   The search string to match against the names of directories in <paramref name="path"/>.
+      ///   This parameter can contain a combination of valid literal path and wildcard
+      ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
+      /// </param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
+      [SecurityCritical]
+      public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, string searchPattern, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<T>(null, path, searchPattern, DirectoryEnumerationOptions.FilesAndFolders, PathFormat.RelativePath, filters);
       }
 
       /// <summary>[AlphaFS] Returns an enumerable collection of file system entries that match a <paramref name="searchPattern"/> in a specified path.</summary>
@@ -240,7 +413,44 @@ namespace Alphaleonis.Win32.Filesystem
          return EnumerateFileSystemEntryInfosCore<T>(null, path, searchPattern, DirectoryEnumerationOptions.FilesAndFolders, pathFormat);
       }
 
-
+      /// <summary>[AlphaFS] Returns an enumerable collection of file system entries that match a <paramref name="searchPattern"/> in a specified path.</summary>
+      /// <returns>The matching file system entries. The type of the items is determined by the type <typeparamref name="T"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <typeparam name="T">The type to return. This may be one of the following types:
+      ///    <list type="definition">
+      ///    <item>
+      ///       <term><see cref="FileSystemEntryInfo"/></term>
+      ///       <description>This method will return instances of <see cref="FileSystemEntryInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="FileSystemInfo"/></term>
+      ///       <description>This method will return instances of <see cref="DirectoryInfo"/> and <see cref="FileInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="string"/></term>
+      ///       <description>This method will return the full path of each item.</description>
+      ///    </item>
+      /// </list>
+      /// </typeparam>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="searchPattern">
+      ///   The search string to match against the names of directories in <paramref name="path"/>.
+      ///   This parameter can contain a combination of valid literal path and wildcard
+      ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
+      /// </param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
+      [SecurityCritical]
+      public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, string searchPattern, PathFormat pathFormat, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<T>(null, path, searchPattern, DirectoryEnumerationOptions.FilesAndFolders, pathFormat, filters);
+      }
 
       /// <summary>[AlphaFS] Returns an enumerable collection of file system entries that match a <paramref name="searchPattern"/> in a specified path using <see cref="DirectoryEnumerationOptions"/>.</summary>
       /// <returns>The matching file system entries. The type of the items is determined by the type <typeparamref name="T"/>.</returns>
@@ -311,12 +521,91 @@ namespace Alphaleonis.Win32.Filesystem
       ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
       /// </param>
       /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
+      [SecurityCritical]
+      public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, string searchPattern, DirectoryEnumerationOptions options, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<T>(null, path, searchPattern, options, PathFormat.RelativePath, filters);
+      }
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of file system entries that match a <paramref name="searchPattern"/> in a specified path using <see cref="DirectoryEnumerationOptions"/>.</summary>
+      /// <returns>The matching file system entries. The type of the items is determined by the type <typeparamref name="T"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <typeparam name="T">The type to return. This may be one of the following types:
+      ///    <list type="definition">
+      ///    <item>
+      ///       <term><see cref="FileSystemEntryInfo"/></term>
+      ///       <description>This method will return instances of <see cref="FileSystemEntryInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="FileSystemInfo"/></term>
+      ///       <description>This method will return instances of <see cref="DirectoryInfo"/> and <see cref="FileInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="string"/></term>
+      ///       <description>This method will return the full path of each item.</description>
+      ///    </item>
+      /// </list>
+      /// </typeparam>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="searchPattern">
+      ///   The search string to match against the names of directories in <paramref name="path"/>.
+      ///   This parameter can contain a combination of valid literal path and wildcard
+      ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
+      /// </param>
+      /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
       /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
       [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
       [SecurityCritical]
       public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, string searchPattern, DirectoryEnumerationOptions options, PathFormat pathFormat)
       {
          return EnumerateFileSystemEntryInfosCore<T>(null, path, searchPattern, options, pathFormat);
+      }
+
+      /// <summary>[AlphaFS] Returns an enumerable collection of file system entries that match a <paramref name="searchPattern"/> in a specified path using <see cref="DirectoryEnumerationOptions"/>.</summary>
+      /// <returns>The matching file system entries. The type of the items is determined by the type <typeparamref name="T"/>.</returns>
+      /// <exception cref="ArgumentException"/>
+      /// <exception cref="ArgumentNullException"/>
+      /// <exception cref="DirectoryNotFoundException"/>
+      /// <exception cref="IOException"/>
+      /// <exception cref="NotSupportedException"/>
+      /// <exception cref="UnauthorizedAccessException"/>
+      /// <typeparam name="T">The type to return. This may be one of the following types:
+      ///    <list type="definition">
+      ///    <item>
+      ///       <term><see cref="FileSystemEntryInfo"/></term>
+      ///       <description>This method will return instances of <see cref="FileSystemEntryInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="FileSystemInfo"/></term>
+      ///       <description>This method will return instances of <see cref="DirectoryInfo"/> and <see cref="FileInfo"/> instances.</description>
+      ///    </item>
+      ///    <item>
+      ///       <term><see cref="string"/></term>
+      ///       <description>This method will return the full path of each item.</description>
+      ///    </item>
+      /// </list>
+      /// </typeparam>
+      /// <param name="path">The directory to search.</param>
+      /// <param name="searchPattern">
+      ///   The search string to match against the names of directories in <paramref name="path"/>.
+      ///   This parameter can contain a combination of valid literal path and wildcard
+      ///   (<see cref="Path.WildcardStarMatchAll"/> and <see cref="Path.WildcardQuestion"/>) characters, but does not support regular expressions.
+      /// </param>
+      /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
+      [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Infos")]
+      [SecurityCritical]
+      public static IEnumerable<T> EnumerateFileSystemEntryInfos<T>(string path, string searchPattern, DirectoryEnumerationOptions options, PathFormat pathFormat, DirectoryEnumerationFilters filters)
+      {
+         return EnumerateFileSystemEntryInfosCore<T>(null, path, searchPattern, options, pathFormat, filters);
       }
 
       #region Transactional
@@ -618,7 +907,7 @@ namespace Alphaleonis.Win32.Filesystem
       {
          return EnumerateFileSystemEntryInfosCore<T>(transaction, path, searchPattern, options, pathFormat);
       }
-      
+
       #endregion // Transactional
 
       #region Internal Methods
@@ -656,13 +945,14 @@ namespace Alphaleonis.Win32.Filesystem
       /// </param>
       /// <param name="options"><see cref="DirectoryEnumerationOptions"/> flags that specify how the directory is to be enumerated.</param>
       /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <param name="filters">The specification of custom filters to be used in the process.</param>
       [SecurityCritical]
-      internal static IEnumerable<T> EnumerateFileSystemEntryInfosCore<T>(KernelTransaction transaction, string path, string searchPattern, DirectoryEnumerationOptions options, PathFormat pathFormat)
+      internal static IEnumerable<T> EnumerateFileSystemEntryInfosCore<T>(KernelTransaction transaction, string path, string searchPattern, DirectoryEnumerationOptions options, PathFormat pathFormat, DirectoryEnumerationFilters filters = null)
       {
          // Enable BasicSearch and LargeCache by default.
          options |= DirectoryEnumerationOptions.BasicSearch | DirectoryEnumerationOptions.LargeCache;
 
-         return new FindFileSystemEntryInfo(true, transaction, path, searchPattern, options, typeof(T), pathFormat).Enumerate<T>();
+         return new FindFileSystemEntryInfo(true, transaction, path, searchPattern, options, typeof(T), pathFormat, filters).Enumerate<T>();
       }
 
       #endregion // Internal Methods

--- a/AlphaFS/Filesystem/Directory Class/Directory.GetDirectoryId.cs
+++ b/AlphaFS/Filesystem/Directory Class/Directory.GetDirectoryId.cs
@@ -1,0 +1,40 @@
+/*  Copyright (C) 2008-2016 Peter Palotas, Jeffrey Jangli, Alexandr Normuradov
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy 
+ *  of this software and associated documentation files (the "Software"), to deal 
+ *  in the Software without restriction, including without limitation the rights 
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ *  copies of the Software, and to permit persons to whom the Software is 
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in 
+ *  all copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ *  THE SOFTWARE. 
+ */
+
+using Microsoft.Win32.SafeHandles;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.AccessControl;
+
+namespace Alphaleonis.Win32.Filesystem
+{
+    public static partial class Directory
+    {
+        /// <summary>[AlphaFS] Retrieves a unique directory identifier.</summary>                
+        /// <remarks>Directory IDs are not guaranteed to be unique over time, because file systems are free to reuse them. In some cases, the file ID for a file can change over time.</remarks>
+        [SecurityCritical]
+        public static FileId GetDirectoryId(string path)
+        {
+            return File.GetFileId(path);
+        }
+    }
+}

--- a/AlphaFS/Filesystem/Directory Class/Directory.GetFileSystemEntryInfo.cs
+++ b/AlphaFS/Filesystem/Directory Class/Directory.GetFileSystemEntryInfo.cs
@@ -1,0 +1,73 @@
+/*  Copyright (C) 2008-2016 Peter Palotas, Jeffrey Jangli, Alexandr Normuradov
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy 
+ *  of this software and associated documentation files (the "Software"), to deal 
+ *  in the Software without restriction, including without limitation the rights 
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ *  copies of the Software, and to permit persons to whom the Software is 
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in 
+ *  all copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ *  THE SOFTWARE. 
+ */
+
+using System;
+using System.Security;
+
+namespace Alphaleonis.Win32.Filesystem
+{
+   public static partial class Directory
+   {
+      #region GetFileSystemEntry
+
+      /// <summary>[AlphaFS] Gets the <see cref="FileSystemEntryInfo"/> of the directory on the path.</summary>
+      /// <returns>The <see cref="FileSystemEntryInfo"/> instance of the directory.</returns>
+      /// <param name="path">The path to the directory.</param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      [SecurityCritical]
+      public static FileSystemEntryInfo GetFileSystemEntryInfo(string path, PathFormat pathFormat)
+      {
+         return File.GetFileSystemEntryInfoCore(true, null, path, false, pathFormat);
+      }
+
+      /// <summary>[AlphaFS] Gets the <see cref="FileSystemEntryInfo"/> of the directory on the path.</summary>
+      /// <returns>The <see cref="FileSystemEntryInfo"/> instance of the directory.</returns>
+      /// <param name="path">The path to the directory.</param>
+      [SecurityCritical]
+      public static FileSystemEntryInfo GetFileSystemEntryInfo(string path)
+      {
+         return File.GetFileSystemEntryInfoCore(true, null, path, false, PathFormat.RelativePath);
+      }
+
+      /// <summary>[AlphaFS] Gets the <see cref="FileSystemEntryInfo"/> of the directory on the path.</summary>
+      /// <returns>The <see cref="FileSystemEntryInfo"/> instance of the directory.</returns>
+      /// <param name="transaction">The transaction.</param>
+      /// <param name="path">The path to the directory.</param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      [SecurityCritical]
+      public static FileSystemEntryInfo GetFileSystemEntryInfoTransacted(KernelTransaction transaction, string path, PathFormat pathFormat)
+      {
+         return File.GetFileSystemEntryInfoCore(true, transaction, path, false, pathFormat);
+      }
+
+      /// <summary>[AlphaFS] Gets the <see cref="FileSystemEntryInfo"/> of the file on the path.</summary>
+      /// <returns>The <see cref="FileSystemEntryInfo"/> instance of the directory.</returns>
+      /// <param name="transaction">The transaction.</param>
+      /// <param name="path">The path to the directory.</param>
+      [SecurityCritical]
+      public static FileSystemEntryInfo GetFileSystemEntryInfoTransacted(KernelTransaction transaction, string path)
+      {
+         return File.GetFileSystemEntryInfoCore(true, transaction, path, false, PathFormat.RelativePath);
+        }
+
+      #endregion // GetFileSystemEntry      
+   }
+}

--- a/AlphaFS/Filesystem/Directory Class/Directory.GetLinkTargetInfo.cs
+++ b/AlphaFS/Filesystem/Directory Class/Directory.GetLinkTargetInfo.cs
@@ -1,0 +1,86 @@
+/*  Copyright (C) 2008-2016 Peter Palotas, Jeffrey Jangli, Alexandr Normuradov
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy 
+ *  of this software and associated documentation files (the "Software"), to deal 
+ *  in the Software without restriction, including without limitation the rights 
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ *  copies of the Software, and to permit persons to whom the Software is 
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in 
+ *  all copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ *  THE SOFTWARE. 
+ */
+
+using Microsoft.Win32.SafeHandles;
+using System.IO;
+using System.Security;
+
+namespace Alphaleonis.Win32.Filesystem
+{
+   public static partial class Directory
+   {
+      #region GetLinkTargetInfo
+
+      /// <summary>[AlphaFS] Gets information about the target of a mount point or symbolic link on an NTFS file system.</summary>
+      /// <param name="path">The path to the reparse point.</param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <returns>
+      ///   An instance of <see cref="LinkTargetInfo"/> or <see cref="SymbolicLinkTargetInfo"/> containing information about the symbolic link
+      ///   or mount point pointed to by <paramref name="path"/>.
+      /// </returns>
+      [SecurityCritical]
+      public static LinkTargetInfo GetLinkTargetInfo(string path, PathFormat pathFormat)
+      {
+         return File.GetLinkTargetInfoCore(null, path, pathFormat);
+      }
+
+      /// <summary>[AlphaFS] Gets information about the target of a mount point or symbolic link on an NTFS file system.</summary>
+      /// <param name="path">The path to the reparse point.</param>
+      /// <returns>
+      ///   An instance of <see cref="LinkTargetInfo"/> or <see cref="SymbolicLinkTargetInfo"/> containing information about the symbolic link
+      ///   or mount point pointed to by <paramref name="path"/>.
+      /// </returns>
+      [SecurityCritical]
+      public static LinkTargetInfo GetLinkTargetInfo(string path)
+      {
+         return File.GetLinkTargetInfoCore(null, path, PathFormat.RelativePath);
+      }
+
+      /// <summary>[AlphaFS] Gets information about the target of a mount point or symbolic link on an NTFS file system.</summary>
+      /// <param name="transaction">The transaction.</param>
+      /// <param name="path">The path to the reparse point.</param>
+      /// <param name="pathFormat">Indicates the format of the path parameter(s).</param>
+      /// <returns>
+      ///   An instance of <see cref="LinkTargetInfo"/> or <see cref="SymbolicLinkTargetInfo"/> containing information about the symbolic link
+      ///   or mount point pointed to by <paramref name="path"/>.
+      /// </returns>
+      [SecurityCritical]
+      public static LinkTargetInfo GetLinkTargetInfoTransacted(KernelTransaction transaction, string path, PathFormat pathFormat)
+      {
+         return File.GetLinkTargetInfoCore(transaction, path, pathFormat);
+      }
+
+      /// <summary>[AlphaFS] Gets information about the target of a mount point or symbolic link on an NTFS file system.</summary>
+      /// <param name="transaction">The transaction.</param>
+      /// <param name="path">The path to the reparse point.</param>
+      /// <returns>
+      ///   An instance of <see cref="LinkTargetInfo"/> or <see cref="SymbolicLinkTargetInfo"/> containing information about the symbolic link
+      ///   or mount point pointed to by <paramref name="path"/>.
+      /// </returns>
+      [SecurityCritical]
+      public static LinkTargetInfo GetLinkTargetInfoTransacted(KernelTransaction transaction, string path)
+      {
+         return File.GetLinkTargetInfoCore(transaction, path, PathFormat.RelativePath);
+      }
+
+      #endregion // GetLinkTargetInfo      
+   }
+}

--- a/AlphaFS/Filesystem/DirectoryEnumerationFilters.cs
+++ b/AlphaFS/Filesystem/DirectoryEnumerationFilters.cs
@@ -1,0 +1,86 @@
+﻿/*  Copyright (C) 2008-2016 Peter Palotas, Jeffrey Jangli, Alexandr Normuradov
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy 
+ *  of this software and associated documentation files (the "Software"), to deal 
+ *  in the Software without restriction, including without limitation the rights 
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ *  copies of the Software, and to permit persons to whom the Software is 
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in 
+ *  all copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ *  THE SOFTWARE. 
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Alphaleonis.Win32.Filesystem
+{
+   /// <summary>
+   /// Represents the method that will handle an error raised during retrieving file system entries.
+   /// </summary>
+   /// <param name="errorCode">The error code.</param>
+   /// <param name="errorMessage">The error message.</param>
+   /// <param name="pathProcessed">The faulty path being processed.</param>
+   /// <returns><see langword="true"/>, if the error has been fully handled and the caller may proceed, 
+   /// <see langword="false"/> otherwise, in which case the caller will throw the corresponding exception.</returns>   
+   public delegate bool ErrorHandler(int errorCode, string errorMessage, string pathProcessed);
+
+   /// <summary>
+   /// [AlphaFS] Specifies a set of custom filters to be used with enumeration methods of <see cref="Directory"/>, 
+   /// e.g., <see cref="Directory.EnumerateDirectories(string)"/>, <see cref="Directory.EnumerateFiles(string)"/>,
+   /// or <see cref="Directory.EnumerateFileSystemEntries(string)"/>.
+   /// </summary>
+   /// <remarks>
+   /// <see cref="DirectoryEnumerationFilters"/> allows scenarios in which files/directories being 
+   /// enumerated by the methods of <see cref="Directory"/> class are accepted only if 
+   /// they match the search pattern, attributes (see <see cref="DirectoryEnumerationOptions.SkipReparsePoints"/>),
+   /// and optionally also the custom criteria tested in the method whose delegate is specified in <see cref="InclusionFilter"/>. 
+   /// These criteria could be, e.g., file size exceeding some threshold, pathname matches a compex regular expression, etc.
+   /// If the enumeration process is set to be recursive (see <see cref="DirectoryEnumerationOptions.Recursive"/>) and <see cref="RecursionFilter"/>
+   /// is specified, the directory is traversed recursively only if it matches the custom criteria in <see cref="RecursionFilter"/> 
+   /// method. This allows, for example, custom handling of junctions and symbolic links, e.g., detection of cycles.
+   /// If any error occurs during the enumeration and the enumeration process is not set to ignore errors
+   /// (see <see cref="DirectoryEnumerationOptions.ContinueOnException"/>), an exception is thrown unless
+   /// the error is handled (filtered out) by the method specified in <see cref="ErrorFilter"/> (if specified).
+   /// The method may, for example, consume the error by reporting it in a log, so that the enumeration
+   /// continues as in the case of <see cref="DirectoryEnumerationOptions.ContinueOnException"/> option
+   /// but the user will be informed about errors.
+   /// </remarks>
+   public class DirectoryEnumerationFilters
+   {
+      /// <summary>
+      /// Gets or sets the filter that returns <see langword="true"/> if the input file system entry should be present in the enumeration.
+      /// </summary>
+      /// <value>
+      /// The delegate to a filtering method.
+      /// </value>      
+      public Predicate<FileSystemEntryInfo> InclusionFilter { get; set; }
+
+      /// <summary>
+      /// Gets or sets the filter that returns <see langword="true"/> if the input directory should be recursively traversed.
+      /// </summary>
+      /// <value>
+      /// The delegate to a filtering method.
+      /// </value>
+      public Predicate<FileSystemEntryInfo> RecursionFilter { get; set; }
+
+      /// <summary>
+      /// Gets or sets the filter that returns <see langword="true"/> if the input error should not be thrown.
+      /// </summary>
+      /// <value>
+      /// The delegate to a filtering method.
+      /// </value>
+      public ErrorHandler ErrorFilter { get; set; }
+   }
+}

--- a/AlphaFS/Filesystem/Enumerations/FileInfoByHandleClass.cs
+++ b/AlphaFS/Filesystem/Enumerations/FileInfoByHandleClass.cs
@@ -138,7 +138,7 @@ namespace Alphaleonis.Win32.Filesystem
          /// <para>will resume the enumeration operation after the last file is returned.</para>
          /// </remarks>
          /// </summary>
-         FileIdBothDirectoryInfo = 10
+         FileIdBothDirectoryInfo = 10,
 
          #endregion // FILE_ID_BOTH_DIR_INFO
 
@@ -227,15 +227,15 @@ namespace Alphaleonis.Win32.Filesystem
 
          #region FILE_ID_INFO
 
-         ///// <summary>FILE_ID_INFO
-         ///// <para>File information should be retrieved. Use for any handles.</para>
-         ///// <para>Use only when calling GetFileInformationByHandleEx.</para>
-         ///// <remarks>
-         ///// <para>Windows Server 2008 R2, Windows 7, Windows Server 2008, Windows Vista, Windows Server 2003, and Windows XP:</para>
-         ///// <para>This value is not supported before Windows 8 and Windows Server 2012</para>
-         ///// </remarks>
-         ///// </summary>
-         //FileIdInfo = 18,
+         /// <summary>FILE_ID_INFO
+         /// <para>File information should be retrieved. Use for any handles.</para>
+         /// <para>Use only when calling GetFileInformationByHandleEx.</para>
+         /// <remarks>
+         /// <para>Windows Server 2008 R2, Windows 7, Windows Server 2008, Windows Vista, Windows Server 2003, and Windows XP:</para>
+         /// <para>This value is not supported before Windows 8 and Windows Server 2012</para>
+         /// </remarks>
+         /// </summary>
+         FileIdInfo = 18,
 
          #endregion // FILE_ID_INFO
 

--- a/AlphaFS/Filesystem/File Class/File.GetFileId.cs
+++ b/AlphaFS/Filesystem/File Class/File.GetFileId.cs
@@ -1,0 +1,66 @@
+/*  Copyright (C) 2008-2016 Peter Palotas, Jeffrey Jangli, Alexandr Normuradov
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy 
+ *  of this software and associated documentation files (the "Software"), to deal 
+ *  in the Software without restriction, including without limitation the rights 
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ *  copies of the Software, and to permit persons to whom the Software is 
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in 
+ *  all copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ *  THE SOFTWARE. 
+ */
+
+using Microsoft.Win32.SafeHandles;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.AccessControl;
+
+namespace Alphaleonis.Win32.Filesystem
+{
+    public static partial class File
+    {
+        /// <summary>[AlphaFS] Retrieves a unique file identifier.</summary>                
+        /// <remarks>File IDs are not guaranteed to be unique over time, because file systems are free to reuse them. In some cases, the file ID for a file can change over time.</remarks>
+        [SecurityCritical]
+        public static FileId GetFileId(string path)
+        {
+            using (var handle = File.CreateFileCore(null, path,
+                ExtendedFileAttributes.BackupSemantics, null, FileMode.Open, FileSystemRights.ReadData,
+                FileShare.ReadWrite, true, PathFormat.RelativePath))
+            {
+                if (NativeMethods.IsAtLeastWindows8)
+                {
+                    //ReFS is supported                    
+                    using (var safeBuffer = new SafeGlobalMemoryBufferHandle(Marshal.SizeOf(typeof(NativeMethods.FILE_ID_INFO))))
+                    {
+                        if (!NativeMethods.GetFileInformationByHandleEx(handle, NativeMethods.FileInfoByHandleClass.FileIdInfo, safeBuffer, (uint)safeBuffer.Capacity))                        
+                            NativeError.ThrowException(Marshal.GetLastWin32Error());
+
+                        NativeMethods.FILE_ID_INFO info = safeBuffer.PtrToStructure<NativeMethods.FILE_ID_INFO>(0);
+                        return new FileId(info);
+                    }
+                }
+                else
+                {
+                    //only NTFS is supported
+                    NativeMethods.BY_HANDLE_FILE_INFORMATION info;
+
+                    if (!NativeMethods.GetFileInformationByHandle(handle, out info))
+                        NativeError.ThrowException(Marshal.GetLastWin32Error());
+
+                    return new FileId(info);
+                }
+            }            
+        }
+    }
+}

--- a/AlphaFS/Filesystem/FileId.cs
+++ b/AlphaFS/Filesystem/FileId.cs
@@ -1,0 +1,249 @@
+/*  Copyright (C) 2008-2016 Peter Palotas, Jeffrey Jangli, Alexandr Normuradov
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy 
+ *  of this software and associated documentation files (the "Software"), to deal 
+ *  in the Software without restriction, including without limitation the rights 
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ *  copies of the Software, and to permit persons to whom the Software is 
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in 
+ *  all copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ *  THE SOFTWARE. 
+ */
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Security;
+
+namespace Alphaleonis.Win32.Filesystem
+{
+    #region FileId
+
+    /// <summary>Contains information that the GetFileInformationByHandle function retrieves.</summary>
+    [Serializable]    
+    public struct FileId : IComparable, IComparable<FileId>, IEquatable<FileId>
+    {
+        #region Private Fields
+        private long _volumeSerialNumber;
+
+        private long _fileIdHighPart;
+
+        private long _fileIdLowPart;
+        #endregion
+
+        #region Constructor
+
+        internal FileId(NativeMethods.BY_HANDLE_FILE_INFORMATION fibh)
+        {
+            _volumeSerialNumber = fibh.dwVolumeSerialNumber;
+
+            _fileIdHighPart = 0;
+            _fileIdLowPart = NativeMethods.ToLong(fibh.nFileIndexHigh, fibh.nFileIndexLow);
+        }
+
+        internal FileId(NativeMethods.FILE_ID_INFO fi)
+        {
+            _volumeSerialNumber = fi.VolumeSerialNumber;
+
+            //the identifier is stored in the array of fi.FileId so that
+            //the lowest byte is at index 0
+
+            ArrayToLong(fi.FileId, 0, 8, out _fileIdLowPart);
+            ArrayToLong(fi.FileId, 8, 8, out _fileIdHighPart);
+        }
+
+        /// <summary>
+        /// Construct the value stored in a byte array ordered in Little-Endian
+        /// </summary>
+        /// <param name="fileId">The array containing the bytes.</param>
+        /// <param name="startIndex">The starting index.</param>
+        /// <param name="count">The number of bytes to convert.</param>
+        /// <param name="value">The output value.</param>        
+        private static void ArrayToLong(byte[] fileId, int startIndex, int count, out long value)
+        {
+            value = 0;
+            for (int i = 0; i < count; i++)
+            {
+                value |= ((long)fileId[startIndex + i]) << (8 * i);
+            }
+        }
+        #endregion // Constructor
+
+        #region IComparable
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.
+        /// </summary>
+        /// <param name="obj">An object to compare with this instance.</param>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared. The return value has these meanings: Value Meaning Less than zero This instance precedes <paramref name="obj" /> in the sort order. Zero This instance occurs in the same position in the sort order as <paramref name="obj" />. Greater than zero This instance follows <paramref name="obj" /> in the sort order.
+        /// </returns>        
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+                return 1;
+
+            if (!(obj is FileId))
+                throw new ArgumentException("Object must be of type FileId");
+
+            return CompareTo((FileId)obj);
+        }
+
+        /// <summary>
+        /// Compares the current object with another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// A value that indicates the relative order of the objects being compared. The return value has the following meanings: Value Meaning Less than zero This object is less than the <paramref name="other" /> parameter.Zero This object is equal to <paramref name="other" />. Greater than zero This object is greater than <paramref name="other" />.
+        /// </returns>        
+        public int CompareTo(FileId other)
+        {
+            if (this._volumeSerialNumber != other._volumeSerialNumber)
+                return Math.Sign(this._volumeSerialNumber - other._volumeSerialNumber);
+
+            if (this._fileIdHighPart != other._fileIdHighPart)
+                return Math.Sign(this._fileIdHighPart - other._fileIdHighPart);
+
+            return Math.Sign(this._fileIdLowPart - other._fileIdLowPart);
+        }
+        #endregion
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (obj == null || !(obj is FileId))
+                return false;
+
+            return Equals((FileId)obj);
+        }
+
+        #region IEquatable
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(FileId other)
+        {
+            return this._fileIdLowPart == other._fileIdLowPart &&
+                this._fileIdHighPart == other._fileIdHighPart &&
+                this._volumeSerialNumber == other._volumeSerialNumber;
+        }
+        #endregion
+
+        /// <summary>
+        /// Indicates whether the values of two specified <see cref="FileId" /> objects are equal.
+        /// </summary>
+        /// <param name="first">The first object to compare.</param>
+        /// <param name="second">The second object to compare.</param>
+        /// <returns>
+        /// true if <paramref name="first" /> and <paramref name="second" /> are equal; otherwise, false.
+        /// </returns>
+        public static bool operator == (FileId first, FileId second)
+        {
+            return first._fileIdLowPart == second._fileIdLowPart &&
+                first._fileIdHighPart == second._fileIdHighPart &&
+                first._volumeSerialNumber == second._volumeSerialNumber;
+        }
+
+        /// <summary>
+        /// Indicates whether the values of two specified <see cref="FileId" /> objects are not equal.
+        /// </summary>
+        /// <param name="first">The first object to compare.</param>
+        /// <param name="second">The second object to compare.</param>
+        /// <returns>
+        /// true if <paramref name="first" /> and <paramref name="second" /> are not equal; otherwise, false.
+        /// </returns>
+        public static bool operator !=(FileId first, FileId second)
+        {
+            return first._fileIdLowPart != second._fileIdLowPart ||
+                first._fileIdHighPart != second._fileIdHighPart ||
+                first._volumeSerialNumber != second._volumeSerialNumber;
+        }
+
+        /// <summary>
+        /// Implements the operator &lt;.
+        /// </summary>
+        /// <param name="first">The first operand.</param>
+        /// <param name="second">The second operand.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator < (FileId first, FileId second)
+        {
+            //N.B. must be tested in this order
+            return first._volumeSerialNumber < second._volumeSerialNumber ||
+                first._fileIdHighPart < second._fileIdHighPart ||
+                first._fileIdLowPart < second._fileIdLowPart;
+        }
+
+        /// <summary>
+        /// Implements the operator &gt;.
+        /// </summary>
+        /// <param name="first">The first operand.</param>
+        /// <param name="second">The second operand.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator >(FileId first, FileId second)
+        {
+            //N.B. must be tested in this order
+            return first._volumeSerialNumber > second._volumeSerialNumber ||
+                first._fileIdHighPart > second._fileIdHighPart ||
+                first._fileIdLowPart > second._fileIdLowPart;
+        }
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                //_fileIdHighPart is 0 on NTFS and should be often 0 on ReFS, thus ignore it
+                return (int)this._fileIdLowPart ^ ((int)(this._fileIdLowPart >> 32) | (int)this._volumeSerialNumber);
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            unchecked
+            {
+                return string.Format(CultureInfo.CurrentCulture, "{0}-{1}-{2} : {3}-{4}-{5}",
+                    ((uint)(_volumeSerialNumber >> 32)).ToString("X", CultureInfo.CurrentCulture),
+                    ((ushort)(_volumeSerialNumber >> 16)).ToString("X", CultureInfo.CurrentCulture),
+                    ((ushort)(_volumeSerialNumber)).ToString("X", CultureInfo.CurrentCulture),
+                    _fileIdHighPart.ToString("X", CultureInfo.CurrentCulture),
+                    ((uint)(_fileIdLowPart >> 32)).ToString("X", CultureInfo.CurrentCulture),
+                    ((uint)_fileIdLowPart).ToString("X", CultureInfo.CurrentCulture));
+            }
+        }
+    }
+
+    #endregion // FileId
+}

--- a/AlphaFS/Filesystem/Native Methods/NativeMethods.Constants.cs
+++ b/AlphaFS/Filesystem/Native Methods/NativeMethods.Constants.cs
@@ -25,6 +25,7 @@ namespace Alphaleonis.Win32.Filesystem
 {
    internal static partial class NativeMethods
    {
+      public static readonly bool IsAtLeastWindows8 = OperatingSystem.IsAtLeast(OperatingSystem.EnumOsName.Windows8);
       public static readonly bool IsAtLeastWindows7 = OperatingSystem.IsAtLeast(OperatingSystem.EnumOsName.Windows7);
       public static readonly bool IsAtLeastWindowsVista = OperatingSystem.IsAtLeast(OperatingSystem.EnumOsName.WindowsVista);
 

--- a/AlphaFS/Filesystem/Native Structures/FILE_ID_INFO.cs
+++ b/AlphaFS/Filesystem/Native Structures/FILE_ID_INFO.cs
@@ -1,0 +1,48 @@
+/*  Copyright (C) 2008-2016 Peter Palotas, Jeffrey Jangli, Alexandr Normuradov
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy 
+ *  of this software and associated documentation files (the "Software"), to deal 
+ *  in the Software without restriction, including without limitation the rights 
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ *  copies of the Software, and to permit persons to whom the Software is 
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in 
+ *  all copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ *  THE SOFTWARE. 
+ */
+
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Alphaleonis.Win32.Filesystem
+{
+    internal static partial class NativeMethods
+    {
+        /// <summary>Contains identification information for a file.</summary>
+        /// <remarks>
+        ///   <para></para>
+        /// </remarks>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct FILE_ID_INFO
+        {
+            /// <summary>
+            /// The serial number of the volume that contains a file.
+            /// </summary>
+            public long VolumeSerialNumber;
+
+            /// <summary>
+            /// The 128-bit file identifier for the file. The file identifier and the volume serial number uniquely identify a file on a single computer. To determine whether two open handles represent the same file, combine the identifier and the volume serial number for each file and compare them.
+            /// </summary>
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public byte[] FileId;
+        }
+    }
+}

--- a/AlphaFS/Filesystem/Path Class/Path.GetFullPath.cs
+++ b/AlphaFS/Filesystem/Path Class/Path.GetFullPath.cs
@@ -172,8 +172,8 @@ namespace Alphaleonis.Win32.Filesystem
       internal static string GetFullPathCore(KernelTransaction transaction, string path, GetFullPathOptions options)
       {
          if (path != null)
-            if (path.StartsWith(GlobalRootPrefix, StringComparison.OrdinalIgnoreCase) ||path.StartsWith(VolumePrefix, StringComparison.OrdinalIgnoreCase))
-               return path;
+            if (path.StartsWith(GlobalRootPrefix, StringComparison.OrdinalIgnoreCase) ||path.StartsWith(VolumePrefix, StringComparison.OrdinalIgnoreCase) || path.StartsWith(SubstitutePrefix, StringComparison.OrdinalIgnoreCase))
+               return path; //skip the special paths recognised by Windows kernel only
          
          if (options != GetFullPathOptions.None)
          {

--- a/AlphaFS/Filesystem/Path Class/Path.ShortLongConversions.cs
+++ b/AlphaFS/Filesystem/Path Class/Path.ShortLongConversions.cs
@@ -146,7 +146,8 @@ namespace Alphaleonis.Win32.Filesystem
          // ".", "C:"
          if (path.Length <= 2 ||
              path.StartsWith(LongPathPrefix, StringComparison.OrdinalIgnoreCase) ||
-             path.StartsWith(LogicalDrivePrefix, StringComparison.OrdinalIgnoreCase))
+             path.StartsWith(LogicalDrivePrefix, StringComparison.OrdinalIgnoreCase) ||
+             path.StartsWith(SubstitutePrefix, StringComparison.OrdinalIgnoreCase))
             return path;
 
          if (path.StartsWith(UncPrefix, StringComparison.OrdinalIgnoreCase))

--- a/AlphaFS/Filesystem/Path Class/Path.ValidationAndChecks.cs
+++ b/AlphaFS/Filesystem/Path Class/Path.ValidationAndChecks.cs
@@ -290,6 +290,7 @@ namespace Alphaleonis.Win32.Filesystem
 
 
       [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
+      [SuppressMessage("Microsoft.Performance", "CA1809:AvoidExcessiveLocals")]
       private static string NormalizePath(string path, GetFullPathOptions options)
       {
          var newBuffer = new StringBuilder(NativeMethods.MaxPathUnicode);

--- a/AlphaFS/Win32Errors.cs
+++ b/AlphaFS/Win32Errors.cs
@@ -258,7 +258,7 @@ namespace Alphaleonis.Win32
       //public const uint ERROR_RELOC_CHAIN_XEEDS_SEGLIM = 201;
       //public const uint ERROR_INFLOOP_IN_RELOC_CHAIN = 202;
 
-      /// <summary>(203) The system could not find the environment option that was entered.</summary>
+      //// <summary>(203) The system could not find the environment option that was entered.</summary>
       //public const uint ERROR_ENVVAR_NOT_FOUND = 203;
 
       //public const uint ERROR_NO_SIGNAL_SENT = 205;
@@ -319,7 +319,7 @@ namespace Alphaleonis.Win32
 
       //public const uint ERROR_IO_INCOMPLETE = 996;
 
-      /// <summary>(997) Overlapped I/O operation is in progress.</summary>
+      //// <summary>(997) Overlapped I/O operation is in progress.</summary>
       //public const uint ERROR_IO_PENDING = 997;
 
       //public const uint ERROR_NOACCESS = 998;
@@ -448,7 +448,7 @@ namespace Alphaleonis.Win32
       //public const uint ERROR_POTENTIAL_FILE_FOUND = 1180;
       //public const uint ERROR_JOURNAL_ENTRY_DELETED = 1181;
 
-      /// <summary>(1200) The specified device name is invalid.</summary>
+      //// <summary>(1200) The specified device name is invalid.</summary>
       //public const uint ERROR_BAD_DEVICE = 1200;
 
       //public const uint ERROR_CONNECTION_UNAVAIL = 1201;
@@ -459,7 +459,7 @@ namespace Alphaleonis.Win32
       //public const uint ERROR_BAD_PROFILE = 1206;
       //public const uint ERROR_NOT_CONTAINER = 1207;
 
-      /// <summary>(1208) An extended error has occurred.</summary>
+      //// <summary>(1208) An extended error has occurred.</summary>
       //public const uint ERROR_EXTENDED_ERROR = 1208;
 
       //public const uint ERROR_INVALID_GROUPNAME = 1209;
@@ -476,7 +476,7 @@ namespace Alphaleonis.Win32
       //public const uint ERROR_REMOTE_SESSION_LIMIT_EXCEEDED = 1220;
       //public const uint ERROR_DUP_DOMAINNAME = 1221;
 
-      /// <summary>(1222) The network is not present or not started.</summary>
+      //// <summary>(1222) The network is not present or not started.</summary>
       //public const uint ERROR_NO_NETWORK = 1222;
 
       //public const uint ERROR_CANCELLED = 1223;
@@ -3558,7 +3558,7 @@ namespace Alphaleonis.Win32
       ///// <summary>This replicant database is outdated; synchronization is required.</summary>
       //public const uint NERR_SyncRequired = 2249;
 
-      /// <summary>(2250) The network connection could not be found.</summary>
+      //// <summary>(2250) The network connection could not be found.</summary>
       //public const uint NERR_UseNotFound = 2250;
 
       ///// <summary>This asg_type is invalid.</summary>
@@ -3645,7 +3645,7 @@ namespace Alphaleonis.Win32
       ///// <summary>This operation is not supported on computers with multiple networks.</summary>
       //public const uint NERR_MultipleNets = 2300;
 
-      /// <summary>(2310) This shared resource does not exist.</summary>
+      //// <summary>(2310) This shared resource does not exist.</summary>
       //public const uint NERR_NetNameNotFound = 2310;
 
       ///// <summary>This device is not shared.</summary>


### PR DESCRIPTION
CURRENT STATE: If you need to get the full path, file attributes, etc. of a file, you just call File.GetFileSystemEntryInfo. It works for any valid path. If you need to get the same info for the directory, you may also call File.GetFileSystemEntryInfo. Problem is that while File.GetFileSystemEntryInfo(@"C:\Temp") returns you the expected structure, File.GetFileSystemEntryInfo(@"C:\") throws an exception. In my opinion, it should work for any valid path. The reason for such a behaviour lies in the way how FileSystemEntryInfo is obtained in AlphaFS: this is done by calling FindFirst native method which for some unknown reasons does not support root paths.

SOLUTION: I added Directory.GetFileSystemEntryInfo method and patched the core in such a way that if the path is passed via  Directory.GetFileSystemEntryInfo and the underlaying call of FindFirst fails, the code assumes that the path is a root directory (e.g., C:\,  C:, \\server\name, \??\Volume{GUID}, ...) and attempts to get the required attributes directly via different technique. Only if this attempt fails, an exception is thrown.