### PR TITLE
Fixed PathTooLongException for boundary case of directory name length in Path.NormalizePath

### DIFF
--- a/AlphaFS/Filesystem/Path Class/Path.ValidationAndChecks.cs
+++ b/AlphaFS/Filesystem/Path Class/Path.ValidationAndChecks.cs
@@ -400,7 +400,7 @@ namespace Alphaleonis.Win32.Filesystem
 
 
                var thisPos = newBuffer.Length - 1;
-               if (thisPos - lastDirectorySeparatorPos > NativeMethods.MaxDirectoryLength)
+               if (thisPos - lastDirectorySeparatorPos - 1 > NativeMethods.MaxDirectoryLength)
                   throw new PathTooLongException(path);
 
                lastDirectorySeparatorPos = thisPos;
@@ -482,7 +482,7 @@ namespace Alphaleonis.Win32.Filesystem
          }
 
 
-         if (newBuffer.Length - 1 - lastDirectorySeparatorPos > NativeMethods.MaxDirectoryLength)
+         if (newBuffer.Length - 1 - lastDirectorySeparatorPos - 1 > NativeMethods.MaxDirectoryLength)
             throw new PathTooLongException(path);
 
 


### PR DESCRIPTION
There is a problem with paths that contain components with maximum length (255 chars in Windows). This paths are valid but Path.NormalizePath method throws exception PathTooLongException. Path.NormalizePath has checks for length of path components but this checks contains miscalculation for one char.