### PR TITLE
Removed overload that will always result in an exception

### DIFF
--- a/src/AlphaFS/Network/Host Class/Host.SMB.EnumerateOpenConnections.cs
+++ b/src/AlphaFS/Network/Host Class/Host.SMB.EnumerateOpenConnections.cs
@@ -29,17 +29,6 @@ namespace Alphaleonis.Win32.Network
 {
    public static partial class Host
    {
-      /// <summary>Enumerates open connections from the local host.</summary>
-      /// <returns><see cref="OpenConnectionInfo"/> connection information from the local host.</returns>
-      /// <exception cref="ArgumentNullException"/>
-      /// <exception cref="NetworkInformationException"/>
-      [SecurityCritical]
-      public static IEnumerable<OpenConnectionInfo> EnumerateOpenConnections()
-      {
-         return EnumerateOpenConnectionsCore(null, null, false);
-      }
-
-
       /// <summary>Enumerates open connections from the specified host.</summary>
       /// <returns><see cref="OpenConnectionInfo"/> connection information from the specified <paramref name="host"/>.</returns>
       /// <exception cref="ArgumentNullException"/>


### PR DESCRIPTION
EnumerateOpenConnectionsCore is called with null in the share parameter. Due to the `if (Utils.IsNullOrWhiteSpace(share))` condition, it will always throw an ArgumentNullException.